### PR TITLE
Add a default library location to Find*.cmake modules.

### DIFF
--- a/nuget/ios/FindLib3MF.iOS.cmake
+++ b/nuget/ios/FindLib3MF.iOS.cmake
@@ -8,4 +8,6 @@ if (NOT Lib3MF_IOS_FOUND)
     set_target_properties(Lib3MF PROPERTIES IMPORTED_LOCATION_RELEASE "${CMAKE_CURRENT_LIST_DIR}/build/native/lib/iOS/Release/static/lib3MF_s.a")
     set_target_properties(Lib3MF PROPERTIES IMPORTED_LOCATION_RELWITHDEBINFO "${CMAKE_CURRENT_LIST_DIR}/build/native/lib/iOS/Release/static/lib3MF_s.a")
     set_target_properties(Lib3MF PROPERTIES IMPORTED_LOCATION_MINSIZEREL "${CMAKE_CURRENT_LIST_DIR}/build/native/lib/iOS/Release/static/lib3MF_s.a")
+    # Default location for other build configurations defaults to Debug
+    set_target_properties(Lib3MF PROPERTIES IMPORTED_LOCATION "${CMAKE_CURRENT_LIST_DIR}/build/native/lib/iOS/Debug/static/lib3MF_s.a")
 endif()

--- a/nuget/ios/FindLib3MF.iOSSimulator64.cmake
+++ b/nuget/ios/FindLib3MF.iOSSimulator64.cmake
@@ -8,4 +8,6 @@ if (NOT Lib3MF_IOSSIMULATOR64_FOUND)
     set_target_properties(Lib3MF PROPERTIES IMPORTED_LOCATION_RELEASE "${CMAKE_CURRENT_LIST_DIR}/build/native/lib/iOSSimulator64/Release/static/lib3MF_s.a")
     set_target_properties(Lib3MF PROPERTIES IMPORTED_LOCATION_RELWITHDEBINFO "${CMAKE_CURRENT_LIST_DIR}/build/native/lib/iOSSimulator64/Release/static/lib3MF_s.a")
     set_target_properties(Lib3MF PROPERTIES IMPORTED_LOCATION_MINSIZEREL "${CMAKE_CURRENT_LIST_DIR}/build/native/lib/iOSSimulator64/Release/static/lib3MF_s.a")
+    # Default location for other build configurations defaults to Debug
+    set_target_properties(Lib3MF PROPERTIES IMPORTED_LOCATION "${CMAKE_CURRENT_LIST_DIR}/build/native/lib/iOSSimulator64/Debug/static/lib3MF_s.a")
 endif()

--- a/nuget/macos/FindLib3MF.macOS.cmake
+++ b/nuget/macos/FindLib3MF.macOS.cmake
@@ -8,4 +8,6 @@ if (NOT Lib3MF_MACOS_FOUND)
     set_target_properties(Lib3MF PROPERTIES IMPORTED_LOCATION_RELEASE "${CMAKE_CURRENT_LIST_DIR}/build/native/lib/x64/Release/static/lib3MF_s.a")
     set_target_properties(Lib3MF PROPERTIES IMPORTED_LOCATION_RELWITHDEBINFO "${CMAKE_CURRENT_LIST_DIR}/build/native/lib/x64/Release/static/lib3MF_s.a")
     set_target_properties(Lib3MF PROPERTIES IMPORTED_LOCATION_MINSIZEREL "${CMAKE_CURRENT_LIST_DIR}/build/native/lib/x64/Release/static/lib3MF_s.a")
+    # Default location for other build configurations defaults to Debug
+    set_target_properties(Lib3MF PROPERTIES IMPORTED_LOCATION "${CMAKE_CURRENT_LIST_DIR}/build/native/lib/x64/Debug/static/lib3MF_s.a")
 endif()


### PR DESCRIPTION
Add a default library location to Find*.cmake modules. This allows the builds that use custom configurations (other than Debug, Release, MinSizeRel and RelWithDebugInfo) to work out of the box.