### PR TITLE
Remove unnecessary zip_source_close

### DIFF
--- a/Include/Common/OPC/NMR_OpcPackageReader.h
+++ b/Include/Common/OPC/NMR_OpcPackageReader.h
@@ -54,7 +54,6 @@ namespace NMR {
 		std::vector<nfByte> m_Buffer;
 		zip_error_t m_ZIPError;
 		zip_t * m_ZIParchive;
-		zip_source_t * m_ZIPsource;
 		std::map <std::wstring, nfUint64> m_ZIPEntries;		
 		std::map <std::wstring, POpcPackagePart> m_Parts;
 

--- a/Source/Common/OPC/NMR_OpcPackageReader.cpp
+++ b/Source/Common/OPC/NMR_OpcPackageReader.cpp
@@ -111,7 +111,7 @@ namespace NMR {
 		m_ZIPError.sys_err = 0;
 		m_ZIPError.zip_err = 0;
 		m_ZIParchive = nullptr;
-		m_ZIPsource = nullptr;
+		zip_source_t* pZIPsource = nullptr;
 
 		try {
 			// determine stream size
@@ -126,18 +126,18 @@ namespace NMR {
 
 			if (true) {
 				// read ZIP from callback: faster and requires less memory
-				m_ZIPsource = zip_source_function_create(custom_zip_source_callback, pImportStream.get(), &m_ZIPError);
+				pZIPsource = zip_source_function_create(custom_zip_source_callback, pImportStream.get(), &m_ZIPError);
 			}
 			else {
 				// read ZIP into memory
 				m_Buffer.resize((size_t)nStreamSize);
 				pImportStream->readBuffer(&m_Buffer[0], nStreamSize, true);
-				m_ZIPsource = zip_source_buffer_create(&m_Buffer[0], (size_t)nStreamSize, 0, &m_ZIPError);
+				pZIPsource = zip_source_buffer_create(&m_Buffer[0], (size_t)nStreamSize, 0, &m_ZIPError);
 			}
-			if (m_ZIPsource == nullptr)
+			if (pZIPsource == nullptr)
 				throw CNMRException(NMR_ERROR_COULDNOTREADZIPFILE);
 
-			m_ZIParchive = zip_open_from_source(m_ZIPsource, ZIP_RDONLY | ZIP_CHECKCONS, &m_ZIPError);
+			m_ZIParchive = zip_open_from_source(pZIPsource, ZIP_RDONLY | ZIP_CHECKCONS, &m_ZIPError);
 			if (m_ZIParchive == nullptr)
 				throw CNMRException(NMR_ERROR_COULDNOTREADZIPFILE);
 
@@ -200,13 +200,9 @@ namespace NMR {
 		if (m_ZIParchive != nullptr)
 			zip_close(m_ZIParchive);
 
-		if (m_ZIPsource != nullptr)
-			zip_source_close(m_ZIPsource);
-
 		zip_error_fini(&m_ZIPError);
 		m_Buffer.resize(0);
 
-		m_ZIPsource = nullptr;
 		m_ZIParchive = nullptr;
 	}
 


### PR DESCRIPTION
Cherry pick of https://github.com/3MFConsortium/lib3mf/commit/82522923707999f272b9fc94f2c6b2f24f0ef843

The gist of the fix is that `zip_close` already frees its referenced `zip_source` and thus calling `zip_source_close` again on the `zip_source` will double free.